### PR TITLE
secret-store-file

### DIFF
--- a/.github/workflows/publish-to-pypi.yml
+++ b/.github/workflows/publish-to-pypi.yml
@@ -1,6 +1,9 @@
-name: Publish Python 🐍 distribution 📦 to PyPI and TestPyPI
+name: Publish Python 🐍 distribution 📦 to PyPI
 
-on: push
+on:
+  release:
+    types:
+      - published
 
 jobs:
   build:
@@ -49,28 +52,3 @@ jobs:
         path: dist/
     - name: Publish distribution 📦 to PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-
-  publish-to-testpypi:
-    name: Publish Python 🐍 distribution 📦 to TestPyPI
-    if: startsWith(github.ref, 'refs/heads/development')
-    needs:
-      - build
-    runs-on: ubuntu-latest
-
-    environment:
-      name: testpypi
-      url: https://test.pypi.org/p/dtPyAppFramework
-
-    permissions:
-      id-token: write  # IMPORTANT: mandatory for trusted publishing
-
-    steps:
-      - name: Download all the dists
-        uses: actions/download-artifact@v3
-        with:
-          name: python-package-distributions
-          path: dist/
-      - name: Publish distribution 📦 to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/

--- a/src/dtPyAppFramework/application.py
+++ b/src/dtPyAppFramework/application.py
@@ -117,7 +117,13 @@ class AbstractApp(object):
 
         elif opts.add_secret:
             arg_parser.add_argument('--name', action='store', type=str, required=True, help="Secret Name")
-            arg_parser.add_argument('--value', action='store', type=str, required=True, help="Secret Value")
+
+            group = arg_parser.add_mutually_exclusive_group(required=True)
+            group.add_argument('--value', action='store', type=str, help="Secret Value")
+            group.add_argument('--file', action='store', type=str, help="File to add to secret")
+
+            arg_parser.add_argument('--store_as', action='store', type=str, default='raw', choices=['raw', 'base64'],
+                                    help="Store file as either base64 or raw")
 
     def exit(self):
         self.exiting()

--- a/src/dtPyAppFramework/process/__init__.py
+++ b/src/dtPyAppFramework/process/__init__.py
@@ -10,6 +10,7 @@ from .multiprocessing import MultiProcessingManager
 import sys
 import os
 import logging
+import base64
 import argparse
 
 
@@ -152,6 +153,9 @@ class ProcessManager():
 
         except KeyboardInterrupt as kbi:
             logging.warning('(KeyboardInterrupt) Exiting application.')
+        except Exception as ex:
+            logging.exception(str(ex))
+        finally:
             if self.exit_procedure:
                 self.exit_procedure()
             if not self.console_app:
@@ -173,8 +177,31 @@ class ProcessManager():
             args: Parsed command-line arguments.
         """
         try:
-            settings.SecretsManager().set_secret(args.name, args.value)
-            logging.info(f'Added secret "{args.name}" to Secret Store.')
+            name = args.name
+            value = None
+            if args.value:
+                value = args.value
+            if args.file:
+                file_path = args.file
+                if not os.path.exists(file_path):
+                    raise FileNotFoundError(f'The file "{file_path}" could not be found.')
+
+                if args.store_as == 'raw':
+                    with open(file_path, 'r') as file:
+                        file_content = file.read()
+                    value = file_content
+                elif args.store_as == 'base64':
+                    with open(file_path, 'rb') as file:
+                        file_content = file.read()
+                    value = base64.b64encode(file_content).decode('utf-8')
+                else:
+                    raise ValueError(f'Invalid store_as value: {args.store_as}')
+
+            if value is None:
+                raise ValueError(f'No "value" was specified for {name}')
+
+            settings.SecretsManager().set_secret(name, value)
+            logging.info(f'Added secret "{name}" to Secret Store.')
             settings.Settings().close()
         except Exception as ex:
             logging.error(f'Error occurred while adding secret {args.name}.  Error: {str(ex)}')


### PR DESCRIPTION
Added ability to store either a value or contents of a file into secret store.  If a file is chosen then by default it will store the raw contents of the file, however, it can be stored as base64 by using the `--store_as` command line argument.